### PR TITLE
Fixes #8

### DIFF
--- a/Portals/_default/Skins/CLIENT_CODE/.stylelintrc
+++ b/Portals/_default/Skins/CLIENT_CODE/.stylelintrc
@@ -8,7 +8,12 @@
     "font-family-no-missing-generic-family-keyword": null,
     "selector-class-pattern": null,
     "selector-max-id": 1,
-    "selector-max-type": [4, {}],
+    "selector-max-type": [
+      4,
+      {
+        "ignore": ["next-sibling"]
+      }
+    ],
     "selector-no-qualifying-type": [
       true,
       {


### PR DESCRIPTION
vscode-stylelint plugin updated the version of Stylelint it uses, so we modify our `.stylelintrc` config.