### PR TITLE
use datetime attribute (EDN templates)

### DIFF
--- a/DesktopModules/EasyDNNnews/Templates/_default/CLIENT_CODE/News/Details_Article_Default.htm
+++ b/DesktopModules/EasyDNNnews/Templates/_default/CLIENT_CODE/News/Details_Article_Default.htm
@@ -38,7 +38,7 @@
       [EasyDNNnews:EndIf:SubTitle]
       <div class="EDN__meta">
         <span class="EDN__meta__author">[EasyDNNnews:Author:Link]</span>
-        <span class="EDN__meta__date"><time pubdate="pubdate">[EasyDNNnews:FormatedDate:MMMM d, yyyy][EasyDNNnews:EndIf:Event]</time></span>
+        <span class="EDN__meta__date"><time datetime="[EasyDNNnews:FormatedDate:MM-dd-yyyy]">[EasyDNNnews:FormatedDate:MMMM d, yyyy][EasyDNNnews:EndIf:Event]</time></span>
         <span class="EDN__article__categories">[EasyDNNnewsLocalizedText:Categories]: [EasyDNNnews:Categories]</span>
       </div>
     </header>

--- a/DesktopModules/EasyDNNnews/Templates/_default/CLIENT_CODE/News/Details_Article_Default.htm
+++ b/DesktopModules/EasyDNNnews/Templates/_default/CLIENT_CODE/News/Details_Article_Default.htm
@@ -38,7 +38,7 @@
       [EasyDNNnews:EndIf:SubTitle]
       <div class="EDN__meta">
         <span class="EDN__meta__author">[EasyDNNnews:Author:Link]</span>
-        <span class="EDN__meta__date"><time datetime="[EasyDNNnews:FormatedDate:MM-dd-yyyy]">[EasyDNNnews:FormatedDate:MMMM d, yyyy][EasyDNNnews:EndIf:Event]</time></span>
+        <span class="EDN__meta__date"><time datetime="[EasyDNNnews:FormatedDate:yyyy-MM-dd]">[EasyDNNnews:FormatedDate:MMMM d, yyyy][EasyDNNnews:EndIf:Event]</time></span>
         <span class="EDN__article__categories">[EasyDNNnewsLocalizedText:Categories]: [EasyDNNnews:Categories]</span>
       </div>
     </header>

--- a/DesktopModules/EasyDNNnews/Templates/_default/CLIENT_CODE/News/List_Article_Default.htm
+++ b/DesktopModules/EasyDNNnews/Templates/_default/CLIENT_CODE/News/List_Article_Default.htm
@@ -25,7 +25,7 @@
 
       <div class="EDN__meta">
         <span class="EDN__meta__author">[EasyDNNnews:Author:Link]</span>
-        <span class="EDN__meta__date"><time datetime="[EasyDNNnews:FormatedDate:MM-dd-yyyy]">[EasyDNNnews:IfNotExists:Event][EasyDNNnews:FormatedDate:MMMM d,
+        <span class="EDN__meta__date"><time datetime="[EasyDNNnews:FormatedDate:yyyy-MM-dd]">[EasyDNNnews:IfNotExists:Event][EasyDNNnews:FormatedDate:MMMM d,
             yyyy][EasyDNNnews:EndIf:Event][EasyDNNnews:IfExists:Event][EasyDNNnews:EventDate][EasyDNNnews:EndIf:Event]</time></span>
       </div>
     </header>

--- a/DesktopModules/EasyDNNnews/Templates/_default/CLIENT_CODE/News/List_Article_Default.htm
+++ b/DesktopModules/EasyDNNnews/Templates/_default/CLIENT_CODE/News/List_Article_Default.htm
@@ -25,7 +25,7 @@
 
       <div class="EDN__meta">
         <span class="EDN__meta__author">[EasyDNNnews:Author:Link]</span>
-        <span class="EDN__meta__date"><time pubdate="pubdate">[EasyDNNnews:IfNotExists:Event][EasyDNNnews:FormatedDate:MMMM d,
+        <span class="EDN__meta__date"><time datetime="[EasyDNNnews:FormatedDate:MM-dd-yyyy]">[EasyDNNnews:IfNotExists:Event][EasyDNNnews:FormatedDate:MMMM d,
             yyyy][EasyDNNnews:EndIf:Event][EasyDNNnews:IfExists:Event][EasyDNNnews:EventDate][EasyDNNnews:EndIf:Event]</time></span>
       </div>
     </header>


### PR DESCRIPTION
`pubdate` is deprecated. The `datetime` attribute "translate dates into machine-readable format, allowing for better search engine results or custom features such as reminders."

Reference: [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time)