### PR TITLE
comment out empty objects

### DIFF
--- a/Portals/_default/Skins/CLIENT_CODE/gulpfile.js/tasks/favicons.js
+++ b/Portals/_default/Skins/CLIENT_CODE/gulpfile.js/tasks/favicons.js
@@ -17,10 +17,10 @@ const FAVICON_DATA = 'real-favicon-generator.json';
 // method. Copy the values from that object into the custom object below. Any
 // values added here will override the default option found in `plugins.js`.
 const CUSTOM_DESIGN_OPTIONS = {
-  ios: {},
-  windows: {},
-  androidChrome: {},
-  safariPinnedTab: {},
+  // ios: {},
+  // windows: {},
+  // androidChrome: {},
+  // safariPinnedTab: {},
 };
 
 // Same thing applies the the settings. If you want to update these options,


### PR DESCRIPTION
I was accidentally overriding the option settings with empty objects, which was causing RealFaviconGenerator to fail — and then broke Gulp.