### PR TITLE
Feature/smart dropdown alignment

### DIFF
--- a/Portals/_default/Skins/CLIENT_CODE/includes/__debug.ascx
+++ b/Portals/_default/Skins/CLIENT_CODE/includes/__debug.ascx
@@ -1,10 +1,11 @@
 <% if (UserCanViewDebug()) { %>
-  <div class="alert alert-warning  m-0" role="alert">
+  <div class="alert alert-warning m-0" role="alert">
     <p>DNN <%=DotNetNuke.Application.DotNetNukeContext.Current.Application.Version.ToString(3) %> / <%=System.Environment.Version.ToString() %> / <%=System.Net.Dns.GetHostName() %></p>
-    <p>Tab ID = <%=PortalSettings.ActiveTab.TabID %></p>
+    <p>Page: TabID=<%=PortalSettings.ActiveTab.TabID %>, Name=<%=PortalSettings.ActiveTab.TabName %>,Title=<%=PortalSettings.ActiveTab.Title %></p>
+    <p>Nav: Level=<%=PortalSettings.ActiveTab.Level %>, Path=<%=PortalSettings.ActiveTab.TabPath %></p>
     <p>QueryString Params = <%=Request.QueryString.ToJson() %></p>
-    <p>Now = <%=DateTime.Now.ToString("F") %></p>
     <p>WAN IP = <%=GetIpAddress() %></p>
+    <p>Datetime = <%=DateTime.Now.ToString("F") %></p>
     <hr />
     <p class="small font-weight-bold">Debug info only visible from ASL WAN IP address and being output from <code>includes/_footer.ascx</code> in Skin.</p>
   </div>

--- a/Portals/_default/Skins/CLIENT_CODE/includes/_header.ascx
+++ b/Portals/_default/Skins/CLIENT_CODE/includes/_header.ascx
@@ -1,3 +1,5 @@
+<!--#include file="../public/icons/all.svg"-->
+
 <header class="header" role="banner">
   <nav class="navbar navbar-expand-md navbar-light" role="navigation">
     <div class="container">

--- a/Portals/_default/Skins/CLIENT_CODE/includes/_header.ascx
+++ b/Portals/_default/Skins/CLIENT_CODE/includes/_header.ascx
@@ -5,11 +5,10 @@
     <div class="container">
       <a
         class="navbar-brand"
+        <%-- href="<%= DotNetNuke.Common.Globals.NavigateURL(PortalSettings.HomeTabId) %>" --%>
         href="/"
         aria-label="_xx___CLIENT_NAME___xx_"
-      >
-        <!--#include file="_logo.ascx"-->
-      </a>
+      ><!--#include file="_logo.ascx"--></a>
 
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>

--- a/Portals/_default/Skins/CLIENT_CODE/menus/NavPrimary/NavPrimary.cshtml
+++ b/Portals/_default/Skins/CLIENT_CODE/menus/NavPrimary/NavPrimary.cshtml
@@ -1,37 +1,72 @@
 @using DotNetNuke.Web.DDRMenu;
 @using System.Dynamic;
 @inherits DotNetNuke.Web.Razor.DotNetNukeWebPage<dynamic>
-@{ var root = Model.Source.root; }
+
+@functions {
+  // Menu config
+  // Placed in `@functions` so `@helper` methods have access to these variables
+  private bool NAV_IS_ALIGNED_RIGHT = true;
+  private bool INCLUDE_DROPDOWN_MENUS = true;
+  private bool INCLUDE_NESTED_DROPDOWNS = true;
+  private bool USE_CUSTOM_DROPDOWN_ICON = true;
+
+  // Utility functions
+  private HtmlString buildTargetAttribute(MenuNode node) {
+    var targetString = !String.IsNullOrEmpty(node.Target) ? ("target=\"" + node.Target + "\"") : "";
+
+    if (node.Target == "_blank") {
+      // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Security_and_privacy_concerns
+      targetString += " rel=\"noopener noreferrer\"";
+    }
+
+    return new HtmlString(targetString);
+  }
+
+  private HtmlString buildDropdownAttributes(MenuNode node) {
+    var attributeString = node.HasChildren() ? ("id=\"tab-" + node.TabId + "-dropdown\" data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"") : "";
+
+    return new HtmlString(attributeString);
+  }
+}
 
 @helper RenderNodes(IList<MenuNode> nodes) {
   if (nodes.Count > 0) {
-    <ul class="navbar-nav ml-auto">
+    var navClasses = new List<string> { "navbar-nav" };
+    if (NAV_IS_ALIGNED_RIGHT) {
+      navClasses.Add("ml-auto");
+    }
+    var navCss = String.Join(" ", navClasses);
+
+    <ul class="@navCss">
       @foreach (var node in nodes) {
-        var HasChildren = node.HasChildren();
+        var itemClasses = new List<string> { "nav-item", "tab-" + node.TabId };
+        var linkClasses = new List<string> { "nav-link" };
 
-        var navItemClasses = new List<string>();
-        navItemClasses.Add("nav-item");
-        navItemClasses.Add("tab-" + node.TabId);
-        if (node.Breadcrumb) { navItemClasses.Add("active"); }
-        if (HasChildren) { navItemClasses.Add("dropdown"); }
-        var navItemCss = new HtmlString((navItemClasses.Count == 0) ? "" : ("class=\"" + String.Join(" ", navItemClasses.ToArray()) + "\""));
+        if (node.Breadcrumb) {
+          itemClasses.Add("active");
+        }
 
-        var navLinkTarget = new HtmlString((string.IsNullOrEmpty(node.Target)) ? "" : ("target=\"" + node.Target + "\""));
-        <li @navItemCss>
-          <a
-            class='nav-link@(HasChildren ? " dropdown-toggle" : "")'
-            href='@(node.Enabled ? node.Url : "#")'
-            @navLinkTarget
-            @{
-              if (HasChildren) {
-                <text>id="tab-@node.TabId-dropdown"</text>
-                <text>data-toggle="dropdown"</text>
-                <text>aria-haspopup="true"</text>
-                <text>aria-expanded="false"</text>
-              }
+        if (node.HasChildren()) {
+          itemClasses.Add("dropdown");
+          linkClasses.Add("dropdown-toggle");
+        }
+
+        var itemCss = String.Join(" ", itemClasses);
+        var linkCss = String.Join(" ", linkClasses);
+        var linkHref = node.Enabled ? node.Url : "#";
+        var targetAttributes = buildTargetAttribute(node);
+        var dropdownAttributes = buildDropdownAttributes(node);
+
+        <li class="@itemCss">
+          <a class="@linkCss" href="@linkHref" @targetAttributes @dropdownAttributes>
+            @node.Text
+            @if (node.HasChildren() && USE_CUSTOM_DROPDOWN_ICON) {
+              <svg class="svg is-icon"><use xlink:href="#icon-chevron-down" /></svg>
             }
-          >@node.Text</a>
-          @RenderChildren(node)
+          </a>
+          @if (INCLUDE_DROPDOWN_MENUS) {
+            @RenderChildren(node)
+          }
         </li>
       }
     </ul>
@@ -41,41 +76,41 @@
 @helper RenderChildren(MenuNode node) {
   var children = node.Children;
   if (children.Count > 0) {
-    <ul class="dropdown-menu" aria-labelledby="tab-@node.TabId-dropdown">
+    var menuClasses = new List<string> { "dropdown-menu" };
+    if (NAV_IS_ALIGNED_RIGHT && node.Last) {
+      menuClasses.Add("dropdown-menu-right");
+    }
+    var menuCss = String.Join(" ", menuClasses);
+
+    <ul class="@menuCss" aria-labelledby="tab-@node.TabId-dropdown">
       @foreach (var child in children) {
-        var HasChildren = child.HasChildren();
+        var itemClasses = new List<string> { "tab-" + child.TabId };
+        var linkClasses = new List<string> { "dropdown-item" };
 
-        var dItemClasses = new List<string>();
-        dItemClasses.Add("tab-" + child.TabId);
-        if (HasChildren) { dItemClasses.Add("dropdown"); }
-        var dItemCss = new HtmlString((dItemClasses.Count == 0) ? "" : (" class=\"" + String.Join(" ", dItemClasses.ToArray()) + "\""));
+        if (child.Breadcrumb) {
+          linkClasses.Add("active");
+        }
 
-        var dLinkClasses = new List<string>();
-        dLinkClasses.Add("dropdown-item");
-        if (child.Breadcrumb) { dLinkClasses.Add("active"); }
-        if (HasChildren) { dLinkClasses.Add("dropdown-toggle"); }
-        var dLinkCss = new HtmlString((dLinkClasses.Count == 0) ? "" : (" class=\"" + String.Join(" ", dLinkClasses.ToArray()) + "\""));
+        if (child.HasChildren()) {
+          itemClasses.Add("dropdown");
+          linkClasses.Add("dropdown-toggle");
+        }
 
-        var dLinkTarget = new HtmlString((string.IsNullOrEmpty(child.Target)) ? "" : ("target=\"" + child.Target + "\""));
-        <li @dItemCss>
-          <a
-            @dLinkCss
-            href='@(child.Enabled ? child.Url : "#")'
-            @dLinkTarget
-            @{
-              if (HasChildren) {
-                <text>id="tab-@child.TabId-dropdown"</text>
-                <text>data-toggle="dropdown"</text>
-                <text>aria-haspopup="true"</text>
-                <text>aria-expanded="false"</text>
-              }
-            }
-          >@child.Text</a>
-          @RenderChildren(child)
+        var itemCss = String.Join(" ", itemClasses);
+        var linkCss = String.Join(" ", linkClasses);
+        var linkHref = child.Enabled ? child.Url : "#";
+        var targetAttributes = buildTargetAttribute(child);
+        var dropdownAttributes = buildDropdownAttributes(child);
+
+        <li class="@itemCss">
+          <a class="@linkCss" href="@linkHref" @targetAttributes @dropdownAttributes>@child.Text</a>
+          @if (INCLUDE_NESTED_DROPDOWNS) {
+            @RenderChildren(child)
+          }
         </li>
       }
     </ul>
   }
 }
 
-@RenderNodes(root.Children)
+@RenderNodes(Model.Source.root.Children)

--- a/Portals/_default/Skins/CLIENT_CODE/menus/NavPrimary/NavPrimary.cshtml
+++ b/Portals/_default/Skins/CLIENT_CODE/menus/NavPrimary/NavPrimary.cshtml
@@ -23,7 +23,7 @@
   }
 
   private HtmlString buildDropdownAttributes(MenuNode node) {
-    var attributeString = node.HasChildren() ? ("id=\"tab-" + node.TabId + "-dropdown\" data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"") : "";
+    var attributeString = INCLUDE_DROPDOWN_MENUS && node.HasChildren() ? ("id=\"tab-" + node.TabId + "-dropdown\" data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"") : "";
 
     return new HtmlString(attributeString);
   }
@@ -60,7 +60,7 @@
         <li class="@itemCss">
           <a class="@linkCss" href="@linkHref" @targetAttributes @dropdownAttributes>
             @node.Text
-            @if (node.HasChildren() && USE_CUSTOM_DROPDOWN_ICON) {
+            @if (INCLUDE_DROPDOWN_MENUS && node.HasChildren() && USE_CUSTOM_DROPDOWN_ICON) {
               <svg class="svg is-icon"><use xlink:href="#icon-chevron-down" /></svg>
             }
           </a>
@@ -91,7 +91,7 @@
           linkClasses.Add("active");
         }
 
-        if (child.HasChildren()) {
+        if (INCLUDE_NESTED_DROPDOWNS && child.HasChildren()) {
           itemClasses.Add("dropdown");
           linkClasses.Add("dropdown-toggle");
         }
@@ -100,7 +100,7 @@
         var linkCss = String.Join(" ", linkClasses);
         var linkHref = child.Enabled ? child.Url : "#";
         var targetAttributes = buildTargetAttribute(child);
-        var dropdownAttributes = buildDropdownAttributes(child);
+        var dropdownAttributes = INCLUDE_NESTED_DROPDOWNS ? buildDropdownAttributes(child) : null;
 
         <li class="@itemCss">
           <a class="@linkCss" href="@linkHref" @targetAttributes @dropdownAttributes>@child.Text</a>

--- a/Portals/_default/Skins/CLIENT_CODE/menus/NavSecondary/NavSecondary.cshtml
+++ b/Portals/_default/Skins/CLIENT_CODE/menus/NavSecondary/NavSecondary.cshtml
@@ -1,37 +1,72 @@
 @using DotNetNuke.Web.DDRMenu;
 @using System.Dynamic;
 @inherits DotNetNuke.Web.Razor.DotNetNukeWebPage<dynamic>
-@{ var root = Model.Source.root; }
+
+@functions {
+  // Menu config
+  // Placed in `@functions` so `@helper` methods have access to these variables
+  private bool NAV_IS_ALIGNED_RIGHT = true;
+  private bool INCLUDE_DROPDOWN_MENUS = true;
+  private bool INCLUDE_NESTED_DROPDOWNS = true;
+  private bool USE_CUSTOM_DROPDOWN_ICON = true;
+
+  // Utility functions
+  private HtmlString buildTargetAttribute(MenuNode node) {
+    var targetString = !String.IsNullOrEmpty(node.Target) ? ("target=\"" + node.Target + "\"") : "";
+
+    if (node.Target == "_blank") {
+      // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#Security_and_privacy_concerns
+      targetString += " rel=\"noopener noreferrer\"";
+    }
+
+    return new HtmlString(targetString);
+  }
+
+  private HtmlString buildDropdownAttributes(MenuNode node) {
+    var attributeString = node.HasChildren() ? ("id=\"tab-" + node.TabId + "-dropdown\" data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"") : "";
+
+    return new HtmlString(attributeString);
+  }
+}
 
 @helper RenderNodes(IList<MenuNode> nodes) {
   if (nodes.Count > 0) {
-    <ul class="navbar-nav ml-auto">
+    var navClasses = new List<string> { "navbar-nav" };
+    if (NAV_IS_ALIGNED_RIGHT) {
+      navClasses.Add("ml-auto");
+    }
+    var navCss = String.Join(" ", navClasses);
+
+    <ul class="@navCss">
       @foreach (var node in nodes) {
-        var HasChildren = node.HasChildren();
+        var itemClasses = new List<string> { "nav-item", "tab-" + node.TabId };
+        var linkClasses = new List<string> { "nav-link" };
 
-        var navItemClasses = new List<string>();
-        navItemClasses.Add("nav-item");
-        navItemClasses.Add("tab-" + node.TabId);
-        if (node.Breadcrumb) { navItemClasses.Add("active"); }
-        if (HasChildren) { navItemClasses.Add("dropdown"); }
-        var navItemCss = new HtmlString((navItemClasses.Count == 0) ? "" : ("class=\"" + String.Join(" ", navItemClasses.ToArray()) + "\""));
+        if (node.Breadcrumb) {
+          itemClasses.Add("active");
+        }
 
-        var navLinkTarget = new HtmlString((string.IsNullOrEmpty(node.Target)) ? "" : ("target=\"" + node.Target + "\""));
-        <li @navItemCss>
-          <a
-            class='nav-link@(HasChildren ? " dropdown-toggle" : "")'
-            href='@(node.Enabled ? node.Url : "#")'
-            @navLinkTarget
-            @{
-              if (HasChildren) {
-                <text>id="tab-@node.TabId-dropdown"</text>
-                <text>data-toggle="dropdown"</text>
-                <text>aria-haspopup="true"</text>
-                <text>aria-expanded="false"</text>
-              }
+        if (node.HasChildren()) {
+          itemClasses.Add("dropdown");
+          linkClasses.Add("dropdown-toggle");
+        }
+
+        var itemCss = String.Join(" ", itemClasses);
+        var linkCss = String.Join(" ", linkClasses);
+        var linkHref = node.Enabled ? node.Url : "#";
+        var targetAttributes = buildTargetAttribute(node);
+        var dropdownAttributes = buildDropdownAttributes(node);
+
+        <li class="@itemCss">
+          <a class="@linkCss" href="@linkHref" @targetAttributes @dropdownAttributes>
+            @node.Text
+            @if (node.HasChildren() && USE_CUSTOM_DROPDOWN_ICON) {
+              <svg class="svg is-icon"><use xlink:href="#icon-chevron-down" /></svg>
             }
-          >@node.Text</a>
-          @RenderChildren(node)
+          </a>
+          @if (INCLUDE_DROPDOWN_MENUS) {
+            @RenderChildren(node)
+          }
         </li>
       }
     </ul>
@@ -41,41 +76,41 @@
 @helper RenderChildren(MenuNode node) {
   var children = node.Children;
   if (children.Count > 0) {
-    <ul class="dropdown-menu" aria-labelledby="tab-@node.TabId-dropdown">
+    var menuClasses = new List<string> { "dropdown-menu" };
+    if (NAV_IS_ALIGNED_RIGHT && node.Last) {
+      menuClasses.Add("dropdown-menu-right");
+    }
+    var menuCss = String.Join(" ", menuClasses);
+
+    <ul class="@menuCss" aria-labelledby="tab-@node.TabId-dropdown">
       @foreach (var child in children) {
-        var HasChildren = child.HasChildren();
+        var itemClasses = new List<string> { "tab-" + child.TabId };
+        var linkClasses = new List<string> { "dropdown-item" };
 
-        var dItemClasses = new List<string>();
-        dItemClasses.Add("tab-" + child.TabId);
-        if (HasChildren) { dItemClasses.Add("dropdown"); }
-        var dItemCss = new HtmlString((dItemClasses.Count == 0) ? "" : (" class=\"" + String.Join(" ", dItemClasses.ToArray()) + "\""));
+        if (child.Breadcrumb) {
+          linkClasses.Add("active");
+        }
 
-        var dLinkClasses = new List<string>();
-        dLinkClasses.Add("dropdown-item");
-        if (child.Breadcrumb) { dLinkClasses.Add("active"); }
-        if (HasChildren) { dLinkClasses.Add("dropdown-toggle"); }
-        var dLinkCss = new HtmlString((dLinkClasses.Count == 0) ? "" : (" class=\"" + String.Join(" ", dLinkClasses.ToArray()) + "\""));
+        if (child.HasChildren()) {
+          itemClasses.Add("dropdown");
+          linkClasses.Add("dropdown-toggle");
+        }
 
-        var dLinkTarget = new HtmlString((string.IsNullOrEmpty(child.Target)) ? "" : ("target=\"" + child.Target + "\""));
-        <li @dItemCss>
-          <a
-            @dLinkCss
-            href='@(child.Enabled ? child.Url : "#")'
-            @dLinkTarget
-            @{
-              if (HasChildren) {
-                <text>id="tab-@child.TabId-dropdown"</text>
-                <text>data-toggle="dropdown"</text>
-                <text>aria-haspopup="true"</text>
-                <text>aria-expanded="false"</text>
-              }
-            }
-          >@child.Text</a>
-          @RenderChildren(child)
+        var itemCss = String.Join(" ", itemClasses);
+        var linkCss = String.Join(" ", linkClasses);
+        var linkHref = child.Enabled ? child.Url : "#";
+        var targetAttributes = buildTargetAttribute(child);
+        var dropdownAttributes = buildDropdownAttributes(child);
+
+        <li class="@itemCss">
+          <a class="@linkCss" href="@linkHref" @targetAttributes @dropdownAttributes>@child.Text</a>
+          @if (INCLUDE_NESTED_DROPDOWNS) {
+            @RenderChildren(child)
+          }
         </li>
       }
     </ul>
   }
 }
 
-@RenderNodes(root.Children)
+@RenderNodes(Model.Source.root.Children)

--- a/Portals/_default/Skins/CLIENT_CODE/menus/NavSecondary/NavSecondary.cshtml
+++ b/Portals/_default/Skins/CLIENT_CODE/menus/NavSecondary/NavSecondary.cshtml
@@ -23,7 +23,7 @@
   }
 
   private HtmlString buildDropdownAttributes(MenuNode node) {
-    var attributeString = node.HasChildren() ? ("id=\"tab-" + node.TabId + "-dropdown\" data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"") : "";
+    var attributeString = INCLUDE_DROPDOWN_MENUS && node.HasChildren() ? ("id=\"tab-" + node.TabId + "-dropdown\" data-toggle=\"dropdown\" aria-haspopup=\"true\" aria-expanded=\"false\"") : "";
 
     return new HtmlString(attributeString);
   }
@@ -60,7 +60,7 @@
         <li class="@itemCss">
           <a class="@linkCss" href="@linkHref" @targetAttributes @dropdownAttributes>
             @node.Text
-            @if (node.HasChildren() && USE_CUSTOM_DROPDOWN_ICON) {
+            @if (INCLUDE_DROPDOWN_MENUS && node.HasChildren() && USE_CUSTOM_DROPDOWN_ICON) {
               <svg class="svg is-icon"><use xlink:href="#icon-chevron-down" /></svg>
             }
           </a>
@@ -91,7 +91,7 @@
           linkClasses.Add("active");
         }
 
-        if (child.HasChildren()) {
+        if (INCLUDE_NESTED_DROPDOWNS && child.HasChildren()) {
           itemClasses.Add("dropdown");
           linkClasses.Add("dropdown-toggle");
         }
@@ -100,7 +100,7 @@
         var linkCss = String.Join(" ", linkClasses);
         var linkHref = child.Enabled ? child.Url : "#";
         var targetAttributes = buildTargetAttribute(child);
-        var dropdownAttributes = buildDropdownAttributes(child);
+        var dropdownAttributes = INCLUDE_NESTED_DROPDOWNS ? buildDropdownAttributes(child) : null;
 
         <li class="@itemCss">
           <a class="@linkCss" href="@linkHref" @targetAttributes @dropdownAttributes>@child.Text</a>

--- a/Portals/_default/Skins/CLIENT_CODE/src/js/modules/lazy-youtube.js
+++ b/Portals/_default/Skins/CLIENT_CODE/src/js/modules/lazy-youtube.js
@@ -30,9 +30,7 @@ function lazyLoadYouTube() {
       iframe.className = 'lazy-yt-item';
       iframe.setAttribute(
         'src',
-        `https://www.youtube.com/embed/${
-          video.dataset.id
-        }?rel=0&autoplay=1&modestbranding=1`
+        `https://www.youtube.com/embed/${video.dataset.id}?rel=0&autoplay=1&modestbranding=1&iv_load_policy=3`
       );
       iframe.setAttribute('allowfullscreen', '');
       while (video.firstChild) {

--- a/Portals/_default/Skins/CLIENT_CODE/src/scss/_abstracts/_variables.scss
+++ b/Portals/_default/Skins/CLIENT_CODE/src/scss/_abstracts/_variables.scss
@@ -719,6 +719,7 @@ $text-muted:                  $gray-600;
 $blockquote-small-color:      $gray-600;
 $blockquote-small-font-size:  $font-size-xs;
 $blockquote-font-size:        1em;
+$blockquote-font-style:       normal;
 
 // Custom variables added by Accuraty
 $blockquote-border-color:     $gray-200;

--- a/Portals/_default/Skins/CLIENT_CODE/src/scss/_components/_rich-text.scss
+++ b/Portals/_default/Skins/CLIENT_CODE/src/scss/_components/_rich-text.scss
@@ -79,6 +79,7 @@
   blockquote {
     padding: 1.5rem;
     font-size: $blockquote-font-size;
+    font-style: $blockquote-font-style;
     background-color: $blockquote-bg-color;
     border-left: $blockquote-border-width solid $blockquote-border-color;
 

--- a/Portals/_default/Skins/CLIENT_CODE/src/scss/_layout/_footer.scss
+++ b/Portals/_default/Skins/CLIENT_CODE/src/scss/_layout/_footer.scss
@@ -21,6 +21,7 @@
 
 .footer {
   font-size: $font-size-sm;
+  color: rgba($white, .8);
   background-color: $gray-700;
 }
 
@@ -54,6 +55,10 @@
 
 .footer-brand {
   display: inline-block;
+
+  & + * {
+    margin-bottom: 1rem;
+  }
 }
 
 
@@ -130,7 +135,6 @@
     border-bottom: $link-border-width solid rgba($white, .1);
 
     @include hover-focus() {
-      color: rgba($white, .85);
       border-color: transparent;
     }
   }

--- a/Portals/_default/Skins/CLIENT_CODE/src/scss/_layout/_footer.scss
+++ b/Portals/_default/Skins/CLIENT_CODE/src/scss/_layout/_footer.scss
@@ -57,7 +57,7 @@
   display: inline-block;
 
   & + * {
-    margin-bottom: 1rem;
+    margin-top: 1rem;
   }
 }
 

--- a/Portals/_default/Skins/CLIENT_CODE/src/scss/_layout/_footer.scss
+++ b/Portals/_default/Skins/CLIENT_CODE/src/scss/_layout/_footer.scss
@@ -32,7 +32,6 @@
 // ===========
 
 .footer a:not(.footer-brand) {
-  border-bottom: $link-border-width solid rgba($white, .075);
 
   @include plain-visited() {
     color: inherit;
@@ -40,7 +39,6 @@
 
   @include hover-focus() {
     color: $white;
-    border-color: transparent;
   }
 }
 
@@ -55,7 +53,7 @@
 // ----------------------------------------------------------------------------
 
 .footer-brand {
-  display: block;
+  display: inline-block;
 }
 
 
@@ -129,11 +127,7 @@
   color: rgba($white, .6);
 
   a {
-    border-bottom-color: rgba($white, .075);
-
-    @include plain-visited() {
-      color: inherit;
-    }
+    border-bottom: $link-border-width solid rgba($white, .1);
 
     @include hover-focus() {
       color: rgba($white, .85);


### PR DESCRIPTION
A refactor of the DDR menus to fix the dropdown alignment bug and add smarter configuration / utility functions. Closes #69.

**Menu changes:**
- Adds some constants to use as configuration settings for easy menu updates:
  - How the nav is aligned (defaults to right).
  - If dropdowns should be included.
  - If nested dropdowns should be included (third level and beyond).
  - If a custom dropdown icon is used (this would be in place of Bootstrap's caret).
- Simplifies how tag attributes (`class`, `href`, `target`, etc.) are generated so we:
  - have better readability,
  - can extract common operations into utility functions,
  - and reduce the number of methods being called.

**Todo:**
- `NavPrimary` and `NavSecondary` are the same thing. Need a better idea of what "secondary" means in this context, and then I want to modify the template to fit.
- Still a lot of reused code, so any suggestions about further simplifications would be great.

---

But this branch got a little messy because I was adding misc updates while setting up RRMA.

**Misc changes (in order of appearance):**
- Add debug output changes.
- Load SVG sprite file (`all.svg`) by default, so we can start off with key icons: caret, social, etc.
- Restore the DNN home URL call as a comment.
- [Remove YouTube annotations](https://developers.google.com/youtube/player_parameters#iv_load_policy) by adding `iv_load_policy=3` to embed link.
- Add variables for controlling `blockquote` font style.
- Set footer color.
- Improve footer links:
  - Only handle plain / hover color with global links (`.footer a`).
  - Make `.footer-brand` inline-block.
  - Handle link bottom border specifically in `.footer-lower`.