### PR TITLE
Modernized __debug.ascx, added URL param trigger

### DIFF
--- a/Portals/_default/Skins/CLIENT_CODE/includes/__debug.ascx
+++ b/Portals/_default/Skins/CLIENT_CODE/includes/__debug.ascx
@@ -3,7 +3,7 @@
 <pre>
 DNN <%=DotNetNuke.Application.DotNetNukeContext.Current.Application.Version.ToString(3) %> / <%=System.Environment.Version.ToString() %> / <%=System.Net.Dns.GetHostName() %>
 Page: TabID=<%=PortalSettings.ActiveTab.TabID %>, Name=<%=PortalSettings.ActiveTab.TabName %>, Title=<%=PortalSettings.ActiveTab.Title %>
-Theme = <strong><%=PortalSettings.DefaultPortalSkin.Split('/')[1].ToUpper() %>, Skin / Container = </strong>/<span title="<%=PortalSettings.ActiveTab.SkinSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.SkinSrc) %></span> / <span title="<%=PortalSettings.ActiveTab.ContainerSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.ContainerSrc) %></span>
+Theme = <strong><%=PortalSettings.DefaultPortalSkin.Split('/')[1].ToUpper() %></strong>, Skin / Container = <span title="<%=PortalSettings.ActiveTab.SkinSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.SkinSrc) %></span> / <span title="<%=PortalSettings.ActiveTab.ContainerSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.ContainerSrc) %></span>
 Published=<%=PortalSettings.ActiveTab.HasBeenPublished %>, IsVisible=<%=PortalSettings.ActiveTab.IsVisible %>
 Nav: DisableLink=<%=PortalSettings.ActiveTab.DisableLink %>, Level=<%=PortalSettings.ActiveTab.Level %>, Path=<%=PortalSettings.ActiveTab.TabPath %>
 QueryString Params = <%=Request.QueryString.ToJson() %>

--- a/Portals/_default/Skins/CLIENT_CODE/includes/__debug.ascx
+++ b/Portals/_default/Skins/CLIENT_CODE/includes/__debug.ascx
@@ -1,18 +1,32 @@
 <% if (UserCanViewDebug()) { %>
   <div class="alert alert-warning m-0" role="alert">
-    <p>DNN <%=DotNetNuke.Application.DotNetNukeContext.Current.Application.Version.ToString(3) %> / <%=System.Environment.Version.ToString() %> / <%=System.Net.Dns.GetHostName() %></p>
-    <p>Page: TabID=<%=PortalSettings.ActiveTab.TabID %>, Name=<%=PortalSettings.ActiveTab.TabName %>,Title=<%=PortalSettings.ActiveTab.Title %></p>
-    <p>Nav: Level=<%=PortalSettings.ActiveTab.Level %>, Path=<%=PortalSettings.ActiveTab.TabPath %></p>
-    <p>QueryString Params = <%=Request.QueryString.ToJson() %></p>
-    <p>WAN IP = <%=GetIpAddress() %></p>
-    <p>Datetime = <%=DateTime.Now.ToString("F") %></p>
-    <hr />
+<pre>
+DNN <%=DotNetNuke.Application.DotNetNukeContext.Current.Application.Version.ToString(3) %> / <%=System.Environment.Version.ToString() %> / <%=System.Net.Dns.GetHostName() %>
+Page: TabID=<%=PortalSettings.ActiveTab.TabID %>, Name=<%=PortalSettings.ActiveTab.TabName %>, Title=<%=PortalSettings.ActiveTab.Title %>
+Theme/Skin/Container is <strong>PDEG</strong>/<span title="<%=PortalSettings.ActiveTab.SkinSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.SkinSrc) %></span>/<span title="<%=PortalSettings.ActiveTab.ContainerSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.ContainerSrc) %></span>
+Published=<%=PortalSettings.ActiveTab.HasBeenPublished %>, IsVisible=<%=PortalSettings.ActiveTab.IsVisible %>
+Nav: DisableLink=<%=PortalSettings.ActiveTab.DisableLink %>, Level=<%=PortalSettings.ActiveTab.Level %>, Path=<%=PortalSettings.ActiveTab.TabPath %>
+QueryString Params = <%=Request.QueryString.ToJson() %>
+WAN IP is <%=GetIpAddress() %>, <%=DateTime.Now.ToString("F") %>
+</pre>
     <p class="small font-weight-bold">Debug info only visible from ASL WAN IP address and being output from <code>includes/_footer.ascx</code> in Skin.</p>
   </div>
 <% } %>
 
 
 <script runat="server">
+  public bool UserCanViewDebug()
+  {
+    var list = new List<string> {
+      "192.241.63.162",   // 309SN
+      "108.220.164.129",  // 712WV (JRF)
+      "67.167.3.4",       // CML
+    };
+    return list.Contains(GetIpAddress()) || UrlOverride();
+  }
+  public bool UrlOverride(string urlParamName = "debug", string urlParamValue = "on") {
+    return Request.QueryString[urlParamName] == urlParamValue;
+  }
   public string GetIpAddress()
   {
       string stringIpAddress;
@@ -22,14 +36,5 @@
           stringIpAddress = Request.ServerVariables["REMOTE_ADDR"];
       }
       return stringIpAddress;
-  }
-  public bool UserCanViewDebug()
-  {
-    var list = new List<string> {
-      "192.241.63.162",   // 309SN
-      "108.220.164.129",  // 712WV (JRF)
-      "67.167.3.4",       // CML
-    };
-    return list.Contains(GetIpAddress());
   }
 </script>

--- a/Portals/_default/Skins/CLIENT_CODE/includes/__debug.ascx
+++ b/Portals/_default/Skins/CLIENT_CODE/includes/__debug.ascx
@@ -1,14 +1,15 @@
 <% if (UserCanViewDebug()) { %>
   <div class="alert alert-warning m-0" role="alert">
-<pre>
-DNN <%=DotNetNuke.Application.DotNetNukeContext.Current.Application.Version.ToString(3) %> / <%=System.Environment.Version.ToString() %> / <%=System.Net.Dns.GetHostName() %>
-Page: TabID=<%=PortalSettings.ActiveTab.TabID %>, Name=<%=PortalSettings.ActiveTab.TabName %>, Title=<%=PortalSettings.ActiveTab.Title %>
-Theme = <strong><%=PortalSettings.DefaultPortalSkin.Split('/')[1].ToUpper() %></strong>, Skin / Container = <span title="<%=PortalSettings.ActiveTab.SkinSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.SkinSrc) %></span> / <span title="<%=PortalSettings.ActiveTab.ContainerSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.ContainerSrc) %></span>
-Published=<%=PortalSettings.ActiveTab.HasBeenPublished %>, IsVisible=<%=PortalSettings.ActiveTab.IsVisible %>
-Nav: DisableLink=<%=PortalSettings.ActiveTab.DisableLink %>, Level=<%=PortalSettings.ActiveTab.Level %>, Path=<%=PortalSettings.ActiveTab.TabPath %>
-QueryString Params = <%=Request.QueryString.ToJson() %>
-WAN IP is <%=GetIpAddress() %>, <%=DateTime.Now.ToString("F") %>
-</pre>
+    <div class="text-monospace">
+      <p>DNN <%=DotNetNuke.Application.DotNetNukeContext.Current.Application.Version.ToString(3) %> / <%=System.Environment.Version.ToString() %> / <%=System.Net.Dns.GetHostName() %></p>
+      <p>Page: TabID=<%=PortalSettings.ActiveTab.TabID %>, Name=<%=PortalSettings.ActiveTab.TabName %>, Title=<%=PortalSettings.ActiveTab.Title %></p>
+      <p>Theme: Skin=<strong><%=PortalSettings.DefaultPortalSkin.Split('/')[1].ToUpper() %></strong>, Layout/Container=<span title="<%=PortalSettings.ActiveTab.SkinSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.SkinSrc) %></span>/<span title="<%=PortalSettings.ActiveTab.ContainerSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.ContainerSrc) %></span></p>
+      <p>Status: Published=<%=PortalSettings.ActiveTab.HasBeenPublished %>, IsVisible=<%=PortalSettings.ActiveTab.IsVisible %></p>
+      <p>Nav: DisableLink=<%=PortalSettings.ActiveTab.DisableLink %>, Level=<%=PortalSettings.ActiveTab.Level %>, Path=<%=PortalSettings.ActiveTab.TabPath %></p>
+      <p>QueryString: Params=<%=Request.QueryString.ToJson() %></p>
+      <p>WAN IP=<%=GetIpAddress() %>, <%=DateTime.Now.ToString("F") %></p>
+    </div>
+    <hr />
     <p class="small font-weight-bold">Debug info only visible from ASL WAN IP address and being output from <code>includes/_footer.ascx</code> in Skin.</p>
   </div>
 <% } %>
@@ -24,17 +25,18 @@ WAN IP is <%=GetIpAddress() %>, <%=DateTime.Now.ToString("F") %>
     };
     return list.Contains(GetIpAddress()) || UrlOverride();
   }
-  public bool UrlOverride(string urlParamName = "debug", string urlParamValue = "on") {
+  public bool UrlOverride(string urlParamName = "debug", string urlParamValue = "on")
+  {
     return Request.QueryString[urlParamName] == urlParamValue;
   }
   public string GetIpAddress()
   {
-      string stringIpAddress;
-      stringIpAddress = Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
-      if (stringIpAddress == null)
-      {
-          stringIpAddress = Request.ServerVariables["REMOTE_ADDR"];
-      }
-      return stringIpAddress;
+    string stringIpAddress;
+    stringIpAddress = Request.ServerVariables["HTTP_X_FORWARDED_FOR"];
+    if (stringIpAddress == null)
+    {
+      stringIpAddress = Request.ServerVariables["REMOTE_ADDR"];
+    }
+    return stringIpAddress;
   }
 </script>

--- a/Portals/_default/Skins/CLIENT_CODE/includes/__debug.ascx
+++ b/Portals/_default/Skins/CLIENT_CODE/includes/__debug.ascx
@@ -3,7 +3,7 @@
 <pre>
 DNN <%=DotNetNuke.Application.DotNetNukeContext.Current.Application.Version.ToString(3) %> / <%=System.Environment.Version.ToString() %> / <%=System.Net.Dns.GetHostName() %>
 Page: TabID=<%=PortalSettings.ActiveTab.TabID %>, Name=<%=PortalSettings.ActiveTab.TabName %>, Title=<%=PortalSettings.ActiveTab.Title %>
-Theme/Skin/Container is <strong>PDEG</strong>/<span title="<%=PortalSettings.ActiveTab.SkinSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.SkinSrc) %></span>/<span title="<%=PortalSettings.ActiveTab.ContainerSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.ContainerSrc) %></span>
+Theme = <strong><%=PortalSettings.DefaultPortalSkin.Split('/')[1].ToUpper() %>, Skin / Container = </strong>/<span title="<%=PortalSettings.ActiveTab.SkinSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.SkinSrc) %></span> / <span title="<%=PortalSettings.ActiveTab.ContainerSrc %>"><%=System.IO.Path.GetFileNameWithoutExtension(PortalSettings.ActiveTab.ContainerSrc) %></span>
 Published=<%=PortalSettings.ActiveTab.HasBeenPublished %>, IsVisible=<%=PortalSettings.ActiveTab.IsVisible %>
 Nav: DisableLink=<%=PortalSettings.ActiveTab.DisableLink %>, Level=<%=PortalSettings.ActiveTab.Level %>, Path=<%=PortalSettings.ActiveTab.TabPath %>
 QueryString Params = <%=Request.QueryString.ToJson() %>


### PR DESCRIPTION
See PDEG output for in use example.
 
The debug output can now be triggered from anywhere by adding /demo/on to the URL (thanks to DNN quick, this doesn't work on the home page without /home/demo/on).