### PR TITLE
Remove unnecessary Popper.js

### DIFF
--- a/Portals/_default/Skins/CLIENT_CODE/includes/_preheader.ascx
+++ b/Portals/_default/Skins/CLIENT_CODE/includes/_preheader.ascx
@@ -86,13 +86,6 @@ Other vendor scripts and custom JS come next.
 />
 
 <dnn:DnnJsInclude
-  FilePath="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
-  ForceProvider="DnnFormBottomProvider"
-  Priority="101"
-  runat="server"
-/>
-
-<dnn:DnnJsInclude
   FilePath="public/js/bootstrap.bundle.min.js"
   PathNameAlias="SkinPath"
   ForceProvider="DnnFormBottomProvider"


### PR DESCRIPTION
Apparently [Popper.js is included in `bootstrap.bundle.js`](https://getbootstrap.com/docs/4.4/getting-started/contents/#js-files). I didn't realize this!